### PR TITLE
Add option for using popular tags in list of categories

### DIFF
--- a/Depressurizer/AutoCat.cs
+++ b/Depressurizer/AutoCat.cs
@@ -218,7 +218,7 @@ namespace Depressurizer {
             string genreString = dbEntry.Genre;
 
             if( UseTags && !String.IsNullOrEmpty( dbEntry.Tags ) ) {
-                genreString += ", " + dbEntry.Tags;
+                genreString += ( !string.IsNullOrEmpty( genreString ) ? ", " : "" ) + dbEntry.Tags;
             }
 
             if( RemoveOtherGenres && genreCategories != null ) {

--- a/Depressurizer/DBEdit/DBEditDlg.Designer.cs
+++ b/Depressurizer/DBEdit/DBEditDlg.Designer.cs
@@ -78,6 +78,7 @@ namespace Depressurizer {
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.statusMsg = new System.Windows.Forms.ToolStripStatusLabel();
             this.statSelected = new System.Windows.Forms.ToolStripStatusLabel();
+            this.colTags = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.mainMenu.SuspendLayout();
             this.grpFilter.SuspendLayout();
             this.statusStrip1.SuspendLayout();
@@ -92,7 +93,6 @@ namespace Depressurizer {
             // 
             // menu_File
             // 
-            resources.ApplyResources(this.menu_File, "menu_File");
             this.menu_File.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.menu_File_Save,
             this.menu_File_SaveAs,
@@ -102,45 +102,46 @@ namespace Depressurizer {
             this.menu_File_Sep2,
             this.menu_File_Exit});
             this.menu_File.Name = "menu_File";
+            resources.ApplyResources(this.menu_File, "menu_File");
             // 
             // menu_File_Save
             // 
-            resources.ApplyResources(this.menu_File_Save, "menu_File_Save");
             this.menu_File_Save.Name = "menu_File_Save";
+            resources.ApplyResources(this.menu_File_Save, "menu_File_Save");
             this.menu_File_Save.Click += new System.EventHandler(this.menu_File_Save_Click);
             // 
             // menu_File_SaveAs
             // 
-            resources.ApplyResources(this.menu_File_SaveAs, "menu_File_SaveAs");
             this.menu_File_SaveAs.Name = "menu_File_SaveAs";
+            resources.ApplyResources(this.menu_File_SaveAs, "menu_File_SaveAs");
             this.menu_File_SaveAs.Click += new System.EventHandler(this.menu_File_SaveAs_Click);
             // 
             // menu_File_Load
             // 
-            resources.ApplyResources(this.menu_File_Load, "menu_File_Load");
             this.menu_File_Load.Name = "menu_File_Load";
+            resources.ApplyResources(this.menu_File_Load, "menu_File_Load");
             this.menu_File_Load.Click += new System.EventHandler(this.menu_File_Load_Click);
             // 
             // menu_File_Sep1
             // 
-            resources.ApplyResources(this.menu_File_Sep1, "menu_File_Sep1");
             this.menu_File_Sep1.Name = "menu_File_Sep1";
+            resources.ApplyResources(this.menu_File_Sep1, "menu_File_Sep1");
             // 
             // menu_File_Clear
             // 
-            resources.ApplyResources(this.menu_File_Clear, "menu_File_Clear");
             this.menu_File_Clear.Name = "menu_File_Clear";
+            resources.ApplyResources(this.menu_File_Clear, "menu_File_Clear");
             this.menu_File_Clear.Click += new System.EventHandler(this.menu_File_Clear_Click);
             // 
             // menu_File_Sep2
             // 
-            resources.ApplyResources(this.menu_File_Sep2, "menu_File_Sep2");
             this.menu_File_Sep2.Name = "menu_File_Sep2";
+            resources.ApplyResources(this.menu_File_Sep2, "menu_File_Sep2");
             // 
             // menu_File_Exit
             // 
-            resources.ApplyResources(this.menu_File_Exit, "menu_File_Exit");
             this.menu_File_Exit.Name = "menu_File_Exit";
+            resources.ApplyResources(this.menu_File_Exit, "menu_File_Exit");
             this.menu_File_Exit.Click += new System.EventHandler(this.menu_File_Exit_Click);
             // 
             // lstGames
@@ -150,7 +151,8 @@ namespace Depressurizer {
             this.colName,
             this.colID,
             this.colGenre,
-            this.colType});
+            this.colType,
+            this.colTags});
             this.lstGames.FullRowSelect = true;
             this.lstGames.GridLines = true;
             this.lstGames.HideSelection = false;
@@ -324,22 +326,26 @@ namespace Depressurizer {
             // 
             // statusStrip1
             // 
-            resources.ApplyResources(this.statusStrip1, "statusStrip1");
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.statusMsg,
             this.statSelected});
+            resources.ApplyResources(this.statusStrip1, "statusStrip1");
             this.statusStrip1.Name = "statusStrip1";
             // 
             // statusMsg
             // 
-            resources.ApplyResources(this.statusMsg, "statusMsg");
             this.statusMsg.Name = "statusMsg";
+            resources.ApplyResources(this.statusMsg, "statusMsg");
             this.statusMsg.Spring = true;
             // 
             // statSelected
             // 
-            resources.ApplyResources(this.statSelected, "statSelected");
             this.statSelected.Name = "statSelected";
+            resources.ApplyResources(this.statSelected, "statSelected");
+            // 
+            // colTags
+            // 
+            resources.ApplyResources(this.colTags, "colTags");
             // 
             // DBEditDlg
             // 
@@ -412,6 +418,7 @@ namespace Depressurizer {
         private System.Windows.Forms.ToolStripStatusLabel statusMsg;
         private System.Windows.Forms.ToolStripMenuItem menu_File_SaveAs;
         private System.Windows.Forms.CheckBox chkAgeGate;
+        private System.Windows.Forms.ColumnHeader colTags;
     }
 }
 

--- a/Depressurizer/DBEdit/DBEditDlg.cs
+++ b/Depressurizer/DBEdit/DBEditDlg.cs
@@ -282,7 +282,7 @@ namespace Depressurizer {
         }
 
         void AddGameToList( GameDBEntry g ) {
-            ListViewItem item = new ListViewItem( new string[] { g.Name, g.Id.ToString(), g.Genre, g.Type.ToString() } );
+            ListViewItem item = new ListViewItem( new string[] { g.Name, g.Id.ToString(), g.Genre, g.Type.ToString(), g.Tags } );
             item.Tag = g;
             lstGames.Items.Add( item );
         }

--- a/Depressurizer/DBEdit/DBEditDlg.resx
+++ b/Depressurizer/DBEdit/DBEditDlg.resx
@@ -117,802 +117,811 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="cmdFetch.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;statusMsg.Name" xml:space="preserve">
-    <value>statusMsg</value>
+  <metadata name="mainMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="menu_File_Save.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+S</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="cmdUpdateUnchecked.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 23</value>
+  <data name="menu_File_Save.Size" type="System.Drawing.Size, System.Drawing">
+    <value>189, 22</value>
   </data>
   <data name="menu_File_Save.Text" xml:space="preserve">
     <value>&amp;Save Database</value>
   </data>
-  <data name="&gt;&gt;chkWebError.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;colName.Name" xml:space="preserve">
-    <value>colName</value>
-  </data>
-  <data name="&gt;&gt;chkAll.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="chkRedirect.Text" xml:space="preserve">
-    <value>IdRedirect</value>
-  </data>
-  <data name="&gt;&gt;cmdUpdateUnchecked.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkRedirect.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="chkNew.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 36</value>
-  </data>
-  <data name="chkSiteError.Text" xml:space="preserve">
-    <value>SiteError</value>
-  </data>
-  <data name="chkWebError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 172</value>
-  </data>
-  <data name="&gt;&gt;statusStrip1.Name" xml:space="preserve">
-    <value>statusStrip1</value>
-  </data>
-  <data name="&gt;&gt;cmdEditGame.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="statSelected.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="&gt;&gt;lstGames.ZOrder" xml:space="preserve">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;cmdStore.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;chkAll.Name" xml:space="preserve">
-    <value>chkAll</value>
-  </data>
-  <data name="&gt;&gt;grpFilter.Name" xml:space="preserve">
-    <value>grpFilter</value>
-  </data>
-  <data name="&gt;&gt;chkAgeGate.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="chkGame.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 53</value>
-  </data>
-  <data name="chkUnknown.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;lstGames.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chkDLC.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="lstGames.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 27</value>
-  </data>
-  <data name="&gt;&gt;chkNonApp.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="cmdEditGame.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="cmdUpdateUnchecked.Text" xml:space="preserve">
-    <value>Update &amp;New</value>
-  </data>
-  <data name="&gt;&gt;cmdAddGame.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;chkSiteError.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="menu_File_Save.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 22</value>
-  </data>
-  <data name="chkAll.Text" xml:space="preserve">
-    <value>All</value>
-  </data>
-  <data name="cmdUpdateUnchecked.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="chkNew.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="menu_File_Exit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 22</value>
-  </data>
-  <data name="&gt;&gt;chkDLC.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkAgeGate.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkUnknown.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="lstGames.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
-  <data name="colID.DisplayIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="$this.Text" xml:space="preserve">
-    <value>Database Editor</value>
-  </data>
-  <data name="&gt;&gt;chkNotFound.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;mainMenu.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chkNonApp.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;colName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkDLC.Name" xml:space="preserve">
-    <value>chkDLC</value>
-  </data>
-  <data name="chkUnknown.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;cmdStore.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;colType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkSiteError.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;menu_File_Load.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkNonApp.Parent" xml:space="preserve">
-    <value>grpFilter</value>
-  </data>
-  <data name="&gt;&gt;chkNotFound.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;colGenre.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="chkNew.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;cmdAddGame.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmdStore.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;chkGame.Name" xml:space="preserve">
-    <value>chkGame</value>
-  </data>
-  <data name="&gt;&gt;colID.Name" xml:space="preserve">
-    <value>colID</value>
-  </data>
-  <data name="menu_File_Exit.Text" xml:space="preserve">
-    <value>Clos&amp;e</value>
-  </data>
-  <data name="menu_File_Load.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 22</value>
-  </data>
-  <data name="chkDLC.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 70</value>
-  </data>
-  <data name="cmdAddGame.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 23</value>
-  </data>
-  <data name="&gt;&gt;cmdFetch.Name" xml:space="preserve">
-    <value>cmdFetch</value>
-  </data>
-  <data name="mainMenu.Text" xml:space="preserve">
-    <value>menuStrip1</value>
-  </data>
-  <data name="&gt;&gt;grpFilter.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cmdAddGame.Name" xml:space="preserve">
-    <value>cmdAddGame</value>
-  </data>
-  <data name="&gt;&gt;cmdUpdateSelected.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;statusStrip1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chkNew.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 17</value>
-  </data>
-  <data name="chkAll.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 19</value>
-  </data>
-  <data name="statusStrip1.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
-  </data>
-  <data name="chkDLC.Text" xml:space="preserve">
-    <value>DLC</value>
-  </data>
-  <data name="cmdAddGame.Text" xml:space="preserve">
-    <value>&amp;Add Game</value>
-  </data>
-  <data name="chkNotFound.Text" xml:space="preserve">
-    <value>NotFound</value>
-  </data>
-  <data name="&gt;&gt;chkAgeGate.Name" xml:space="preserve">
-    <value>chkAgeGate</value>
-  </data>
-  <data name="grpFilter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="cmdDeleteGame.Location" type="System.Drawing.Point, System.Drawing">
-    <value>543, 326</value>
-  </data>
-  <data name="&gt;&gt;cmdDeleteGame.Name" xml:space="preserve">
-    <value>cmdDeleteGame</value>
-  </data>
-  <data name="&gt;&gt;menu_File_Exit.Name" xml:space="preserve">
-    <value>menu_File_Exit</value>
-  </data>
-  <data name="chkNotFound.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 17</value>
-  </data>
-  <data name="cmdStore.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;statusStrip1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.StatusStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkAgeGate.Parent" xml:space="preserve">
-    <value>grpFilter</value>
-  </data>
-  <data name="chkGame.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkUnknown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 189</value>
-  </data>
-  <data name="&gt;&gt;chkNotFound.Name" xml:space="preserve">
-    <value>chkNotFound</value>
-  </data>
-  <data name="&gt;&gt;menu_File_Sep1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;mainMenu.ZOrder" xml:space="preserve">
-    <value>10</value>
-  </data>
-  <data name="&gt;&gt;chkSiteError.Parent" xml:space="preserve">
-    <value>grpFilter</value>
-  </data>
-  <data name="&gt;&gt;mainMenu.Name" xml:space="preserve">
-    <value>mainMenu</value>
-  </data>
-  <data name="chkNonApp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 104</value>
-  </data>
-  <data name="&gt;&gt;menu_File_Load.Name" xml:space="preserve">
-    <value>menu_File_Load</value>
-  </data>
-  <data name="&gt;&gt;chkSiteError.ZOrder" xml:space="preserve">
-    <value>8</value>
-  </data>
-  <data name="&gt;&gt;chkRedirect.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkWebError.Parent" xml:space="preserve">
-    <value>grpFilter</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>DBEditDlg</value>
-  </data>
-  <data name="&gt;&gt;chkUnknown.Name" xml:space="preserve">
-    <value>chkUnknown</value>
-  </data>
-  <data name="chkDLC.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="grpFilter.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 209</value>
-  </data>
-  <data name="colGenre.Width" type="System.Int32, mscorlib">
-    <value>105</value>
-  </data>
-  <data name="chkRedirect.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cmdUpdateSelected.Name" xml:space="preserve">
-    <value>cmdUpdateSelected</value>
-  </data>
-  <data name="mainMenu.Size" type="System.Drawing.Size, System.Drawing">
-    <value>669, 24</value>
-  </data>
-  <data name="cmdUpdateSelected.Location" type="System.Drawing.Point, System.Drawing">
-    <value>543, 382</value>
-  </data>
-  <data name="&gt;&gt;menu_File.Name" xml:space="preserve">
-    <value>menu_File</value>
-  </data>
-  <data name="&gt;&gt;cmdUpdateUnchecked.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="menu_File_SaveAs.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+Alt+S</value>
   </data>
   <data name="menu_File_SaveAs.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 22</value>
-  </data>
-  <data name="chkNonApp.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="chkNotFound.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="chkAgeGate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 138</value>
-  </data>
-  <data name="&gt;&gt;chkNew.Name" xml:space="preserve">
-    <value>chkNew</value>
-  </data>
-  <data name="&gt;&gt;chkNotFound.Parent" xml:space="preserve">
-    <value>grpFilter</value>
-  </data>
-  <data name="chkUnknown.Text" xml:space="preserve">
-    <value>Unknown</value>
-  </data>
-  <data name="menu_File_Exit.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Alt+F4</value>
-  </data>
-  <data name="&gt;&gt;cmdDeleteGame.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="grpFilter.Location" type="System.Drawing.Point, System.Drawing">
-    <value>547, 56</value>
-  </data>
-  <data name="chkSiteError.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 17</value>
-  </data>
-  <data name="statusStrip1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 435</value>
-  </data>
-  <data name="&gt;&gt;chkRedirect.Parent" xml:space="preserve">
-    <value>grpFilter</value>
-  </data>
-  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
-    <value>CenterParent</value>
-  </data>
-  <data name="&gt;&gt;cmdUpdateSelected.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>189, 22</value>
   </data>
   <data name="menu_File_SaveAs.Text" xml:space="preserve">
     <value>Save &amp;As...</value>
   </data>
-  <data name="chkAll.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 17</value>
+  <data name="menu_File_Load.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+L</value>
   </data>
-  <data name="&gt;&gt;chkDLC.Parent" xml:space="preserve">
-    <value>grpFilter</value>
+  <data name="menu_File_Load.Size" type="System.Drawing.Size, System.Drawing">
+    <value>189, 22</value>
   </data>
-  <data name="colName.DisplayIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;menu_File_Sep1.Name" xml:space="preserve">
-    <value>menu_File_Sep1</value>
-  </data>
-  <data name="&gt;&gt;cmdEditGame.Name" xml:space="preserve">
-    <value>cmdEditGame</value>
-  </data>
-  <data name="&gt;&gt;chkRedirect.Name" xml:space="preserve">
-    <value>chkRedirect</value>
-  </data>
-  <data name="&gt;&gt;menu_File.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;chkSiteError.Name" xml:space="preserve">
-    <value>chkSiteError</value>
-  </data>
-  <data name="chkSiteError.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;chkNew.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmdAddGame.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;cmdUpdateUnchecked.Name" xml:space="preserve">
-    <value>cmdUpdateUnchecked</value>
-  </data>
-  <data name="chkSiteError.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 155</value>
-  </data>
-  <data name="lstGames.Size" type="System.Drawing.Size, System.Drawing">
-    <value>525, 405</value>
-  </data>
-  <data name="colGenre.Text" xml:space="preserve">
-    <value>Genre</value>
-  </data>
-  <data name="&gt;&gt;chkAll.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="menu_File_Load.Text" xml:space="preserve">
+    <value>&amp;Load...</value>
   </data>
   <data name="menu_File_Sep1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>206, 6</value>
+    <value>186, 6</value>
   </data>
-  <data name="chkGame.Size" type="System.Drawing.Size, System.Drawing">
-    <value>54, 17</value>
+  <data name="menu_File_Clear.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Ctrl+C</value>
   </data>
-  <data name="colType.Width" type="System.Int32, mscorlib">
-    <value>87</value>
+  <data name="menu_File_Clear.Size" type="System.Drawing.Size, System.Drawing">
+    <value>189, 22</value>
   </data>
-  <data name="chkUnknown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 17</value>
+  <data name="menu_File_Clear.Text" xml:space="preserve">
+    <value>&amp;Clear</value>
   </data>
-  <data name="menu_File_SaveAs.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+Alt+S</value>
+  <data name="menu_File_Sep2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>186, 6</value>
   </data>
-  <data name="&gt;&gt;menu_File_SaveAs.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="menu_File_Exit.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
+    <value>Alt+F4</value>
   </data>
-  <data name="chkNotFound.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 121</value>
+  <data name="menu_File_Exit.Size" type="System.Drawing.Size, System.Drawing">
+    <value>189, 22</value>
   </data>
-  <data name="&gt;&gt;cmdEditGame.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;chkWebError.Name" xml:space="preserve">
-    <value>chkWebError</value>
-  </data>
-  <data name="&gt;&gt;cmdEditGame.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="cmdEditGame.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="cmdDeleteGame.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 23</value>
-  </data>
-  <data name="statusStrip1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>669, 22</value>
-  </data>
-  <data name="&gt;&gt;cmdAddGame.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;colGenre.Name" xml:space="preserve">
-    <value>colGenre</value>
-  </data>
-  <data name="cmdUpdateSelected.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;statusStrip1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="cmdDeleteGame.Text" xml:space="preserve">
-    <value>&amp;Delete Game</value>
-  </data>
-  <data name="chkAll.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="statusMsg.Size" type="System.Drawing.Size, System.Drawing">
-    <value>654, 17</value>
+  <data name="menu_File_Exit.Text" xml:space="preserve">
+    <value>Clos&amp;e</value>
   </data>
   <data name="menu_File.Size" type="System.Drawing.Size, System.Drawing">
     <value>37, 20</value>
   </data>
-  <data name="chkNew.Text" xml:space="preserve">
-    <value>New</value>
+  <data name="menu_File.Text" xml:space="preserve">
+    <value>File</value>
   </data>
-  <data name="menu_File_Clear.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 22</value>
+  <data name="mainMenu.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
   </data>
-  <data name="cmdEditGame.Location" type="System.Drawing.Point, System.Drawing">
-    <value>543, 350</value>
+  <data name="mainMenu.Size" type="System.Drawing.Size, System.Drawing">
+    <value>669, 24</value>
   </data>
-  <data name="cmdUpdateSelected.Text" xml:space="preserve">
-    <value>&amp;Update Selected</value>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="mainMenu.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="cmdFetch.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="mainMenu.Text" xml:space="preserve">
+    <value>menuStrip1</value>
   </data>
-  <data name="cmdStore.Location" type="System.Drawing.Point, System.Drawing">
-    <value>543, 271</value>
+  <data name="&gt;&gt;mainMenu.Name" xml:space="preserve">
+    <value>mainMenu</value>
   </data>
-  <data name="&gt;&gt;menu_File_Save.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;mainMenu.Type" xml:space="preserve">
+    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>669, 457</value>
-  </data>
-  <data name="cmdFetch.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 23</value>
-  </data>
-  <data name="&gt;&gt;grpFilter.Parent" xml:space="preserve">
+  <data name="&gt;&gt;mainMenu.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;colType.Name" xml:space="preserve">
-    <value>colType</value>
+  <data name="&gt;&gt;mainMenu.ZOrder" xml:space="preserve">
+    <value>10</value>
   </data>
-  <data name="&gt;&gt;chkNew.ZOrder" xml:space="preserve">
-    <value>9</value>
+  <data name="lstGames.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Bottom, Left, Right</value>
   </data>
-  <data name="cmdStore.Text" xml:space="preserve">
-    <value>View &amp;Store</value>
+  <data name="colName.DisplayIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;menu_File_Clear.Name" xml:space="preserve">
-    <value>menu_File_Clear</value>
-  </data>
-  <data name="&gt;&gt;cmdFetch.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;menu_File_Sep2.Name" xml:space="preserve">
-    <value>menu_File_Sep2</value>
-  </data>
-  <data name="menu_File_Save.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+S</value>
-  </data>
-  <data name="&gt;&gt;cmdUpdateUnchecked.ZOrder" xml:space="preserve">
-    <value>7</value>
-  </data>
-  <data name="cmdEditGame.Text" xml:space="preserve">
-    <value>&amp;Edit Game</value>
-  </data>
-  <data name="&gt;&gt;cmdUpdateSelected.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="grpFilter.Text" xml:space="preserve">
-    <value>Filter</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="cmdEditGame.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 23</value>
-  </data>
-  <data name="&gt;&gt;chkNonApp.Name" xml:space="preserve">
-    <value>chkNonApp</value>
-  </data>
-  <data name="chkWebError.Text" xml:space="preserve">
-    <value>WebError</value>
+  <data name="colName.Text" xml:space="preserve">
+    <value>Name</value>
   </data>
   <data name="colName.Width" type="System.Int32, mscorlib">
-    <value>266</value>
+    <value>207</value>
   </data>
-  <data name="chkNonApp.Text" xml:space="preserve">
-    <value>NonApp</value>
-  </data>
-  <data name="cmdDeleteGame.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
-  </data>
-  <data name="cmdFetch.Text" xml:space="preserve">
-    <value>&amp;Fetch List</value>
+  <data name="colID.DisplayIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
   <data name="colID.Text" xml:space="preserve">
     <value>ID</value>
   </data>
-  <data name="statSelected.Size" type="System.Drawing.Size, System.Drawing">
-    <value>0, 17</value>
+  <data name="colGenre.Text" xml:space="preserve">
+    <value>Genre</value>
   </data>
-  <data name="&gt;&gt;chkNew.Parent" xml:space="preserve">
-    <value>grpFilter</value>
+  <data name="colGenre.Width" type="System.Int32, mscorlib">
+    <value>105</value>
   </data>
-  <data name="&gt;&gt;chkGame.ZOrder" xml:space="preserve">
-    <value>7</value>
+  <data name="colType.Text" xml:space="preserve">
+    <value>Type</value>
   </data>
-  <data name="chkRedirect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 17</value>
+  <data name="colType.Width" type="System.Int32, mscorlib">
+    <value>87</value>
   </data>
-  <data name="cmdFetch.Location" type="System.Drawing.Point, System.Drawing">
-    <value>543, 27</value>
+  <data name="colTags.Text" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="lstGames.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 27</value>
+  </data>
+  <data name="lstGames.Size" type="System.Drawing.Size, System.Drawing">
+    <value>525, 405</value>
+  </data>
+  <data name="lstGames.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
   <data name="&gt;&gt;lstGames.Name" xml:space="preserve">
     <value>lstGames</value>
   </data>
-  <data name="&gt;&gt;statSelected.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lstGames.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;grpFilter.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;lstGames.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
-  <data name="mainMenu.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="&gt;&gt;lstGames.ZOrder" xml:space="preserve">
+    <value>9</value>
   </data>
-  <data name="menu_File.Text" xml:space="preserve">
-    <value>File</value>
+  <data name="cmdFetch.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
-  <data name="cmdStore.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="cmdFetch.Location" type="System.Drawing.Point, System.Drawing">
+    <value>543, 27</value>
+  </data>
+  <data name="cmdFetch.Size" type="System.Drawing.Size, System.Drawing">
     <value>114, 23</value>
   </data>
-  <data name="&gt;&gt;statSelected.Name" xml:space="preserve">
-    <value>statSelected</value>
+  <data name="cmdFetch.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="cmdAddGame.Location" type="System.Drawing.Point, System.Drawing">
-    <value>543, 302</value>
+  <data name="cmdFetch.Text" xml:space="preserve">
+    <value>&amp;Fetch List</value>
   </data>
-  <data name="&gt;&gt;cmdStore.Parent" xml:space="preserve">
+  <data name="&gt;&gt;cmdFetch.Name" xml:space="preserve">
+    <value>cmdFetch</value>
+  </data>
+  <data name="&gt;&gt;cmdFetch.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdFetch.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;cmdFetch.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="chkWebError.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 17</value>
+  <data name="cmdUpdateUnchecked.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
   </data>
-  <data name="&gt;&gt;menu_File_SaveAs.Name" xml:space="preserve">
-    <value>menu_File_SaveAs</value>
+  <data name="cmdUpdateUnchecked.Location" type="System.Drawing.Point, System.Drawing">
+    <value>543, 406</value>
   </data>
-  <data name="cmdAddGame.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="cmdUpdateUnchecked.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 23</value>
+  </data>
+  <data name="cmdUpdateUnchecked.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="cmdUpdateUnchecked.Text" xml:space="preserve">
+    <value>Update &amp;New</value>
+  </data>
+  <data name="&gt;&gt;cmdUpdateUnchecked.Name" xml:space="preserve">
+    <value>cmdUpdateUnchecked</value>
+  </data>
+  <data name="&gt;&gt;cmdUpdateUnchecked.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdUpdateUnchecked.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdUpdateUnchecked.ZOrder" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="cmdUpdateSelected.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Bottom, Right</value>
+  </data>
+  <data name="cmdUpdateSelected.Location" type="System.Drawing.Point, System.Drawing">
+    <value>543, 382</value>
   </data>
   <data name="cmdUpdateSelected.Size" type="System.Drawing.Size, System.Drawing">
     <value>114, 23</value>
   </data>
-  <data name="statusStrip1.Text" xml:space="preserve">
-    <value>statusStrip1</value>
+  <data name="cmdUpdateSelected.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="cmdUpdateSelected.Text" xml:space="preserve">
+    <value>&amp;Update Selected</value>
+  </data>
+  <data name="&gt;&gt;cmdUpdateSelected.Name" xml:space="preserve">
+    <value>cmdUpdateSelected</value>
+  </data>
+  <data name="&gt;&gt;cmdUpdateSelected.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdUpdateSelected.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdUpdateSelected.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="cmdEditGame.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cmdEditGame.Location" type="System.Drawing.Point, System.Drawing">
+    <value>543, 350</value>
+  </data>
+  <data name="cmdEditGame.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 23</value>
+  </data>
+  <data name="cmdEditGame.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="cmdEditGame.Text" xml:space="preserve">
+    <value>&amp;Edit Game</value>
+  </data>
+  <data name="&gt;&gt;cmdEditGame.Name" xml:space="preserve">
+    <value>cmdEditGame</value>
+  </data>
+  <data name="&gt;&gt;cmdEditGame.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdEditGame.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdEditGame.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="cmdDeleteGame.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cmdDeleteGame.Location" type="System.Drawing.Point, System.Drawing">
+    <value>543, 326</value>
+  </data>
+  <data name="cmdDeleteGame.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 23</value>
+  </data>
+  <data name="cmdDeleteGame.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="cmdDeleteGame.Text" xml:space="preserve">
+    <value>&amp;Delete Game</value>
+  </data>
+  <data name="&gt;&gt;cmdDeleteGame.Name" xml:space="preserve">
+    <value>cmdDeleteGame</value>
+  </data>
+  <data name="&gt;&gt;cmdDeleteGame.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdDeleteGame.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdDeleteGame.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="cmdAddGame.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cmdAddGame.Location" type="System.Drawing.Point, System.Drawing">
+    <value>543, 302</value>
+  </data>
+  <data name="cmdAddGame.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 23</value>
+  </data>
+  <data name="cmdAddGame.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="cmdAddGame.Text" xml:space="preserve">
+    <value>&amp;Add Game</value>
+  </data>
+  <data name="&gt;&gt;cmdAddGame.Name" xml:space="preserve">
+    <value>cmdAddGame</value>
+  </data>
+  <data name="&gt;&gt;cmdAddGame.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdAddGame.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdAddGame.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="grpFilter.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="chkAgeGate.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkAgeGate.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 138</value>
+  </data>
+  <data name="chkAgeGate.Size" type="System.Drawing.Size, System.Drawing">
+    <value>68, 17</value>
+  </data>
+  <data name="chkAgeGate.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="chkAgeGate.Text" xml:space="preserve">
+    <value>AgeGate</value>
+  </data>
+  <data name="&gt;&gt;chkAgeGate.Name" xml:space="preserve">
+    <value>chkAgeGate</value>
+  </data>
+  <data name="&gt;&gt;chkAgeGate.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkAgeGate.Parent" xml:space="preserve">
+    <value>grpFilter</value>
+  </data>
+  <data name="&gt;&gt;chkAgeGate.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="chkUnknown.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkUnknown.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 189</value>
+  </data>
+  <data name="chkUnknown.Size" type="System.Drawing.Size, System.Drawing">
+    <value>72, 17</value>
+  </data>
+  <data name="chkUnknown.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="chkUnknown.Text" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="&gt;&gt;chkUnknown.Name" xml:space="preserve">
+    <value>chkUnknown</value>
+  </data>
+  <data name="&gt;&gt;chkUnknown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkUnknown.Parent" xml:space="preserve">
+    <value>grpFilter</value>
+  </data>
+  <data name="&gt;&gt;chkUnknown.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="chkWebError.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkWebError.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 172</value>
+  </data>
+  <data name="chkWebError.Size" type="System.Drawing.Size, System.Drawing">
+    <value>71, 17</value>
+  </data>
+  <data name="chkWebError.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="chkWebError.Text" xml:space="preserve">
+    <value>WebError</value>
+  </data>
+  <data name="&gt;&gt;chkWebError.Name" xml:space="preserve">
+    <value>chkWebError</value>
+  </data>
+  <data name="&gt;&gt;chkWebError.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkWebError.Parent" xml:space="preserve">
+    <value>grpFilter</value>
   </data>
   <data name="&gt;&gt;chkWebError.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="chkNonApp.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkNonApp.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 104</value>
+  </data>
+  <data name="chkNonApp.Size" type="System.Drawing.Size, System.Drawing">
+    <value>65, 17</value>
+  </data>
+  <data name="chkNonApp.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="chkNonApp.Text" xml:space="preserve">
+    <value>NonApp</value>
+  </data>
+  <data name="&gt;&gt;chkNonApp.Name" xml:space="preserve">
+    <value>chkNonApp</value>
+  </data>
+  <data name="&gt;&gt;chkNonApp.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkNonApp.Parent" xml:space="preserve">
+    <value>grpFilter</value>
+  </data>
+  <data name="&gt;&gt;chkNonApp.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="chkRedirect.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkRedirect.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 87</value>
+  </data>
+  <data name="chkRedirect.Size" type="System.Drawing.Size, System.Drawing">
+    <value>75, 17</value>
+  </data>
+  <data name="chkRedirect.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="chkRedirect.Text" xml:space="preserve">
+    <value>IdRedirect</value>
+  </data>
+  <data name="&gt;&gt;chkRedirect.Name" xml:space="preserve">
+    <value>chkRedirect</value>
+  </data>
+  <data name="&gt;&gt;chkRedirect.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkRedirect.Parent" xml:space="preserve">
+    <value>grpFilter</value>
+  </data>
+  <data name="&gt;&gt;chkRedirect.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="chkNotFound.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkNotFound.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 121</value>
+  </data>
+  <data name="chkNotFound.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 17</value>
+  </data>
+  <data name="chkNotFound.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="chkNotFound.Text" xml:space="preserve">
+    <value>NotFound</value>
+  </data>
+  <data name="&gt;&gt;chkNotFound.Name" xml:space="preserve">
+    <value>chkNotFound</value>
+  </data>
+  <data name="&gt;&gt;chkNotFound.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkNotFound.Parent" xml:space="preserve">
+    <value>grpFilter</value>
+  </data>
+  <data name="&gt;&gt;chkNotFound.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="chkDLC.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkDLC.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 70</value>
+  </data>
+  <data name="chkDLC.Size" type="System.Drawing.Size, System.Drawing">
+    <value>47, 17</value>
+  </data>
+  <data name="chkDLC.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="chkDLC.Text" xml:space="preserve">
+    <value>DLC</value>
+  </data>
+  <data name="&gt;&gt;chkDLC.Name" xml:space="preserve">
+    <value>chkDLC</value>
+  </data>
+  <data name="&gt;&gt;chkDLC.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkDLC.Parent" xml:space="preserve">
+    <value>grpFilter</value>
+  </data>
+  <data name="&gt;&gt;chkDLC.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="chkGame.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkGame.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 53</value>
+  </data>
+  <data name="chkGame.Size" type="System.Drawing.Size, System.Drawing">
+    <value>54, 17</value>
+  </data>
+  <data name="chkGame.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="chkGame.Text" xml:space="preserve">
     <value>Game</value>
   </data>
-  <data name="cmdUpdateSelected.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
-  </data>
-  <data name="&gt;&gt;menu_File_Clear.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="grpFilter.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;cmdFetch.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;mainMenu.Type" xml:space="preserve">
-    <value>System.Windows.Forms.MenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;cmdStore.Name" xml:space="preserve">
-    <value>cmdStore</value>
+  <data name="&gt;&gt;chkGame.Name" xml:space="preserve">
+    <value>chkGame</value>
   </data>
   <data name="&gt;&gt;chkGame.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="chkAgeGate.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chkAll.Parent" xml:space="preserve">
-    <value>grpFilter</value>
-  </data>
-  <data name="lstGames.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="mainMenu.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="cmdUpdateUnchecked.Location" type="System.Drawing.Point, System.Drawing">
-    <value>543, 406</value>
-  </data>
-  <data name="chkDLC.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 17</value>
-  </data>
   <data name="&gt;&gt;chkGame.Parent" xml:space="preserve">
     <value>grpFilter</value>
   </data>
-  <data name="menu_File_Clear.Text" xml:space="preserve">
-    <value>&amp;Clear</value>
+  <data name="&gt;&gt;chkGame.ZOrder" xml:space="preserve">
+    <value>7</value>
   </data>
-  <data name="chkAgeGate.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+  <data name="chkSiteError.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="cmdUpdateUnchecked.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Bottom, Right</value>
+  <data name="chkSiteError.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 155</value>
   </data>
-  <data name="&gt;&gt;chkNonApp.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="chkSiteError.Size" type="System.Drawing.Size, System.Drawing">
+    <value>66, 17</value>
   </data>
-  <data name="chkRedirect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 87</value>
+  <data name="chkSiteError.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
   </data>
-  <data name="chkAgeGate.Text" xml:space="preserve">
-    <value>AgeGate</value>
+  <data name="chkSiteError.Text" xml:space="preserve">
+    <value>SiteError</value>
   </data>
-  <data name="statusMsg.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
+  <data name="&gt;&gt;chkSiteError.Name" xml:space="preserve">
+    <value>chkSiteError</value>
   </data>
-  <data name="chkNotFound.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
+  <data name="&gt;&gt;chkSiteError.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="menu_File_Load.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+L</value>
-  </data>
-  <data name="menu_File_Clear.ShortcutKeys" type="System.Windows.Forms.Keys, System.Windows.Forms">
-    <value>Ctrl+C</value>
-  </data>
-  <data name="&gt;&gt;cmdDeleteGame.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;menu_File_Sep2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="menu_File_Load.Text" xml:space="preserve">
-    <value>&amp;Load...</value>
-  </data>
-  <data name="colName.Text" xml:space="preserve">
-    <value>Name</value>
-  </data>
-  <data name="&gt;&gt;menu_File_Save.Name" xml:space="preserve">
-    <value>menu_File_Save</value>
-  </data>
-  <data name="&gt;&gt;chkDLC.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="colType.Text" xml:space="preserve">
-    <value>Type</value>
-  </data>
-  <data name="chkNonApp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>65, 17</value>
-  </data>
-  <data name="&gt;&gt;cmdDeleteGame.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="chkAgeGate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>68, 17</value>
-  </data>
-  <data name="&gt;&gt;chkUnknown.Parent" xml:space="preserve">
+  <data name="&gt;&gt;chkSiteError.Parent" xml:space="preserve">
     <value>grpFilter</value>
   </data>
-  <data name="&gt;&gt;statusMsg.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;colID.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;lstGames.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ListView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="chkGame.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="chkWebError.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;chkSiteError.ZOrder" xml:space="preserve">
     <value>8</value>
   </data>
-  <data name="menu_File_Sep2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>206, 6</value>
-  </data>
-  <data name="chkWebError.AutoSize" type="System.Boolean, mscorlib">
+  <data name="chkNew.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="chkNew.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 36</value>
+  </data>
+  <data name="chkNew.Size" type="System.Drawing.Size, System.Drawing">
+    <value>48, 17</value>
+  </data>
+  <data name="chkNew.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="chkNew.Text" xml:space="preserve">
+    <value>New</value>
+  </data>
+  <data name="&gt;&gt;chkNew.Name" xml:space="preserve">
+    <value>chkNew</value>
+  </data>
+  <data name="&gt;&gt;chkNew.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;chkNew.Parent" xml:space="preserve">
+    <value>grpFilter</value>
+  </data>
+  <data name="&gt;&gt;chkNew.ZOrder" xml:space="preserve">
+    <value>9</value>
+  </data>
+  <data name="chkAll.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="chkAll.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 19</value>
+  </data>
+  <data name="chkAll.Size" type="System.Drawing.Size, System.Drawing">
+    <value>37, 17</value>
   </data>
   <data name="chkAll.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;menu_File_Exit.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="chkAll.Text" xml:space="preserve">
+    <value>All</value>
   </data>
-  <data name="cmdDeleteGame.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="&gt;&gt;chkAll.Name" xml:space="preserve">
+    <value>chkAll</value>
   </data>
-  <data name="chkRedirect.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="&gt;&gt;chkUnknown.Type" xml:space="preserve">
+  <data name="&gt;&gt;chkAll.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>685, 495</value>
+  <data name="&gt;&gt;chkAll.Parent" xml:space="preserve">
+    <value>grpFilter</value>
+  </data>
+  <data name="&gt;&gt;chkAll.ZOrder" xml:space="preserve">
+    <value>10</value>
+  </data>
+  <data name="grpFilter.Location" type="System.Drawing.Point, System.Drawing">
+    <value>547, 56</value>
+  </data>
+  <data name="grpFilter.Size" type="System.Drawing.Size, System.Drawing">
+    <value>110, 209</value>
+  </data>
+  <data name="grpFilter.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="grpFilter.Text" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="&gt;&gt;grpFilter.Name" xml:space="preserve">
+    <value>grpFilter</value>
+  </data>
+  <data name="&gt;&gt;grpFilter.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;grpFilter.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;grpFilter.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="cmdStore.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="cmdStore.Location" type="System.Drawing.Point, System.Drawing">
+    <value>543, 271</value>
+  </data>
+  <data name="cmdStore.Size" type="System.Drawing.Size, System.Drawing">
+    <value>114, 23</value>
+  </data>
+  <data name="cmdStore.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="cmdStore.Text" xml:space="preserve">
+    <value>View &amp;Store</value>
+  </data>
+  <data name="&gt;&gt;cmdStore.Name" xml:space="preserve">
+    <value>cmdStore</value>
+  </data>
+  <data name="&gt;&gt;cmdStore.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cmdStore.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;cmdStore.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>127, 17</value>
+  </metadata>
+  <data name="statusMsg.Size" type="System.Drawing.Size, System.Drawing">
+    <value>654, 17</value>
+  </data>
+  <data name="statusMsg.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="statSelected.Size" type="System.Drawing.Size, System.Drawing">
+    <value>0, 17</value>
+  </data>
+  <data name="statSelected.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="statusStrip1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 435</value>
+  </data>
+  <data name="statusStrip1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>669, 22</value>
+  </data>
+  <data name="statusStrip1.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
+  </data>
+  <data name="statusStrip1.Text" xml:space="preserve">
+    <value>statusStrip1</value>
+  </data>
+  <data name="&gt;&gt;statusStrip1.Name" xml:space="preserve">
+    <value>statusStrip1</value>
+  </data>
+  <data name="&gt;&gt;statusStrip1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.StatusStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;statusStrip1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;statusStrip1.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="mainMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>127, 17</value>
-  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
+    <value>669, 457</value>
+  </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>685, 495</value>
+  </data>
+  <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
+    <value>CenterParent</value>
+  </data>
+  <data name="$this.Text" xml:space="preserve">
+    <value>Database Editor</value>
+  </data>
+  <data name="&gt;&gt;menu_File.Name" xml:space="preserve">
+    <value>menu_File</value>
+  </data>
+  <data name="&gt;&gt;menu_File.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Save.Name" xml:space="preserve">
+    <value>menu_File_Save</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Save.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menu_File_SaveAs.Name" xml:space="preserve">
+    <value>menu_File_SaveAs</value>
+  </data>
+  <data name="&gt;&gt;menu_File_SaveAs.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Load.Name" xml:space="preserve">
+    <value>menu_File_Load</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Load.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Sep1.Name" xml:space="preserve">
+    <value>menu_File_Sep1</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Sep1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Clear.Name" xml:space="preserve">
+    <value>menu_File_Clear</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Clear.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Sep2.Name" xml:space="preserve">
+    <value>menu_File_Sep2</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Sep2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Exit.Name" xml:space="preserve">
+    <value>menu_File_Exit</value>
+  </data>
+  <data name="&gt;&gt;menu_File_Exit.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colName.Name" xml:space="preserve">
+    <value>colName</value>
+  </data>
+  <data name="&gt;&gt;colName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colID.Name" xml:space="preserve">
+    <value>colID</value>
+  </data>
+  <data name="&gt;&gt;colID.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colGenre.Name" xml:space="preserve">
+    <value>colGenre</value>
+  </data>
+  <data name="&gt;&gt;colGenre.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colType.Name" xml:space="preserve">
+    <value>colType</value>
+  </data>
+  <data name="&gt;&gt;colType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;statusMsg.Name" xml:space="preserve">
+    <value>statusMsg</value>
+  </data>
+  <data name="&gt;&gt;statusMsg.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;statSelected.Name" xml:space="preserve">
+    <value>statSelected</value>
+  </data>
+  <data name="&gt;&gt;statSelected.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripStatusLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;colTags.Name" xml:space="preserve">
+    <value>colTags</value>
+  </data>
+  <data name="&gt;&gt;colTags.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>DBEditDlg</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/Depressurizer/Depressurizer.csproj
+++ b/Depressurizer/Depressurizer.csproj
@@ -79,6 +79,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Depressurizer/DlgAutoCat.Designer.cs
+++ b/Depressurizer/DlgAutoCat.Designer.cs
@@ -31,6 +31,7 @@
             this.grpList = new System.Windows.Forms.GroupBox();
             this.panEditGenre = new System.Windows.Forms.Panel();
             this.grpEditGenre = new System.Windows.Forms.GroupBox();
+            this.genreChkUseTags = new System.Windows.Forms.CheckBox();
             this.genreHelpRemoveExisting = new System.Windows.Forms.LinkLabel();
             this.genreHelpPrefix = new System.Windows.Forms.LinkLabel();
             this.genreLblPrefix = new System.Windows.Forms.Label();
@@ -45,8 +46,10 @@
             this.genreNumMaxCats = new System.Windows.Forms.NumericUpDown();
             this.cmdSave = new System.Windows.Forms.Button();
             this.cmdCancel = new System.Windows.Forms.Button();
+            this.splitContainer = new System.Windows.Forms.SplitContainer();
             this.panEditFlags = new System.Windows.Forms.Panel();
             this.flagsGrp = new System.Windows.Forms.GroupBox();
+            this.flagsHelpPrefix = new System.Windows.Forms.LinkLabel();
             this.flagsTbl = new System.Windows.Forms.TableLayoutPanel();
             this.flagsCmdCheckAll = new System.Windows.Forms.Button();
             this.flagsCmdUncheckAll = new System.Windows.Forms.Button();
@@ -54,21 +57,19 @@
             this.flagsLstIncluded = new System.Windows.Forms.ListView();
             this.flagsTxtPrefix = new System.Windows.Forms.TextBox();
             this.flagsLblPrefix = new System.Windows.Forms.Label();
-            this.splitContainer = new System.Windows.Forms.SplitContainer();
             this.ttHelp = new System.Windows.Forms.ToolTip(this.components);
-            this.flagsHelpPrefix = new System.Windows.Forms.LinkLabel();
             this.grpList.SuspendLayout();
             this.panEditGenre.SuspendLayout();
             this.grpEditGenre.SuspendLayout();
             this.genreTblIgnore.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.genreNumMaxCats)).BeginInit();
-            this.panEditFlags.SuspendLayout();
-            this.flagsGrp.SuspendLayout();
-            this.flagsTbl.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
             this.splitContainer.Panel1.SuspendLayout();
             this.splitContainer.Panel2.SuspendLayout();
             this.splitContainer.SuspendLayout();
+            this.panEditFlags.SuspendLayout();
+            this.flagsGrp.SuspendLayout();
+            this.flagsTbl.SuspendLayout();
             this.SuspendLayout();
             // 
             // lstAutoCats
@@ -146,6 +147,7 @@
             // 
             // grpEditGenre
             // 
+            this.grpEditGenre.Controls.Add(this.genreChkUseTags);
             this.grpEditGenre.Controls.Add(this.genreHelpRemoveExisting);
             this.grpEditGenre.Controls.Add(this.genreHelpPrefix);
             this.grpEditGenre.Controls.Add(this.genreLblPrefix);
@@ -164,10 +166,21 @@
             this.grpEditGenre.TabStop = false;
             this.grpEditGenre.Text = "Edit Genre AutoCat";
             // 
+            // genreChkUseTags
+            // 
+            this.genreChkUseTags.AutoSize = true;
+            this.genreChkUseTags.Location = new System.Drawing.Point(46, 96);
+            this.genreChkUseTags.Name = "genreChkUseTags";
+            this.genreChkUseTags.Size = new System.Drawing.Size(144, 17);
+            this.genreChkUseTags.TabIndex = 11;
+            this.genreChkUseTags.Text = "Use Popular Steam Tags";
+            this.genreChkUseTags.UseVisualStyleBackColor = true;
+            this.genreChkUseTags.CheckedChanged += new System.EventHandler(this.genreChkUseTags_CheckChanged);
+            // 
             // genreHelpRemoveExisting
             // 
             this.genreHelpRemoveExisting.AutoSize = true;
-            this.genreHelpRemoveExisting.Location = new System.Drawing.Point(238, 86);
+            this.genreHelpRemoveExisting.Location = new System.Drawing.Point(238, 79);
             this.genreHelpRemoveExisting.Name = "genreHelpRemoveExisting";
             this.genreHelpRemoveExisting.Size = new System.Drawing.Size(13, 13);
             this.genreHelpRemoveExisting.TabIndex = 10;
@@ -265,7 +278,7 @@
             // genreChkRemoveExisting
             // 
             this.genreChkRemoveExisting.AutoSize = true;
-            this.genreChkRemoveExisting.Location = new System.Drawing.Point(46, 82);
+            this.genreChkRemoveExisting.Location = new System.Drawing.Point(46, 77);
             this.genreChkRemoveExisting.Name = "genreChkRemoveExisting";
             this.genreChkRemoveExisting.Size = new System.Drawing.Size(186, 17);
             this.genreChkRemoveExisting.TabIndex = 4;
@@ -275,7 +288,7 @@
             // genreLblMacCats
             // 
             this.genreLblMacCats.AutoSize = true;
-            this.genreLblMacCats.Location = new System.Drawing.Point(64, 47);
+            this.genreLblMacCats.Location = new System.Drawing.Point(64, 44);
             this.genreLblMacCats.Name = "genreLblMacCats";
             this.genreLblMacCats.Size = new System.Drawing.Size(148, 26);
             this.genreLblMacCats.TabIndex = 3;
@@ -283,7 +296,7 @@
             // 
             // genreNumMaxCats
             // 
-            this.genreNumMaxCats.Location = new System.Drawing.Point(6, 50);
+            this.genreNumMaxCats.Location = new System.Drawing.Point(6, 46);
             this.genreNumMaxCats.Maximum = new decimal(new int[] {
             5,
             0,
@@ -318,6 +331,28 @@
             this.cmdCancel.Text = "Cancel";
             this.cmdCancel.UseVisualStyleBackColor = true;
             // 
+            // splitContainer
+            // 
+            this.splitContainer.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.splitContainer.Location = new System.Drawing.Point(4, 4);
+            this.splitContainer.Name = "splitContainer";
+            // 
+            // splitContainer.Panel1
+            // 
+            this.splitContainer.Panel1.Controls.Add(this.grpList);
+            this.splitContainer.Panel1MinSize = 125;
+            // 
+            // splitContainer.Panel2
+            // 
+            this.splitContainer.Panel2.Controls.Add(this.panEditGenre);
+            this.splitContainer.Panel2.Controls.Add(this.panEditFlags);
+            this.splitContainer.Panel2MinSize = 250;
+            this.splitContainer.Size = new System.Drawing.Size(611, 262);
+            this.splitContainer.SplitterDistance = 197;
+            this.splitContainer.TabIndex = 7;
+            // 
             // panEditFlags
             // 
             this.panEditFlags.Controls.Add(this.flagsGrp);
@@ -342,6 +377,16 @@
             this.flagsGrp.TabIndex = 0;
             this.flagsGrp.TabStop = false;
             this.flagsGrp.Text = "Edit Flag Autocat";
+            // 
+            // flagsHelpPrefix
+            // 
+            this.flagsHelpPrefix.AutoSize = true;
+            this.flagsHelpPrefix.Location = new System.Drawing.Point(238, 22);
+            this.flagsHelpPrefix.Name = "flagsHelpPrefix";
+            this.flagsHelpPrefix.Size = new System.Drawing.Size(13, 13);
+            this.flagsHelpPrefix.TabIndex = 5;
+            this.flagsHelpPrefix.TabStop = true;
+            this.flagsHelpPrefix.Text = "?";
             // 
             // flagsTbl
             // 
@@ -421,38 +466,6 @@
             this.flagsLblPrefix.TabIndex = 0;
             this.flagsLblPrefix.Text = "Prefix:";
             // 
-            // splitContainer
-            // 
-            this.splitContainer.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.splitContainer.Location = new System.Drawing.Point(4, 4);
-            this.splitContainer.Name = "splitContainer";
-            // 
-            // splitContainer.Panel1
-            // 
-            this.splitContainer.Panel1.Controls.Add(this.grpList);
-            this.splitContainer.Panel1MinSize = 125;
-            // 
-            // splitContainer.Panel2
-            // 
-            this.splitContainer.Panel2.Controls.Add(this.panEditFlags);
-            this.splitContainer.Panel2.Controls.Add(this.panEditGenre);
-            this.splitContainer.Panel2MinSize = 250;
-            this.splitContainer.Size = new System.Drawing.Size(611, 262);
-            this.splitContainer.SplitterDistance = 197;
-            this.splitContainer.TabIndex = 7;
-            // 
-            // flagsHelpPrefix
-            // 
-            this.flagsHelpPrefix.AutoSize = true;
-            this.flagsHelpPrefix.Location = new System.Drawing.Point(238, 22);
-            this.flagsHelpPrefix.Name = "flagsHelpPrefix";
-            this.flagsHelpPrefix.Size = new System.Drawing.Size(13, 13);
-            this.flagsHelpPrefix.TabIndex = 5;
-            this.flagsHelpPrefix.TabStop = true;
-            this.flagsHelpPrefix.Text = "?";
-            // 
             // DlgAutoCat
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -474,14 +487,14 @@
             this.grpEditGenre.PerformLayout();
             this.genreTblIgnore.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.genreNumMaxCats)).EndInit();
-            this.panEditFlags.ResumeLayout(false);
-            this.flagsGrp.ResumeLayout(false);
-            this.flagsGrp.PerformLayout();
-            this.flagsTbl.ResumeLayout(false);
             this.splitContainer.Panel1.ResumeLayout(false);
             this.splitContainer.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).EndInit();
             this.splitContainer.ResumeLayout(false);
+            this.panEditFlags.ResumeLayout(false);
+            this.flagsGrp.ResumeLayout(false);
+            this.flagsGrp.PerformLayout();
+            this.flagsTbl.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -507,8 +520,14 @@
         private System.Windows.Forms.Button cmdCancel;
         private System.Windows.Forms.Label genreLblPrefix;
         private System.Windows.Forms.TextBox genreTxtPrefix;
+        private System.Windows.Forms.SplitContainer splitContainer;
+        private System.Windows.Forms.LinkLabel genreHelpPrefix;
+        private System.Windows.Forms.LinkLabel genreHelpRemoveExisting;
+        private System.Windows.Forms.ToolTip ttHelp;
+        private System.Windows.Forms.CheckBox genreChkUseTags;
         private System.Windows.Forms.Panel panEditFlags;
         private System.Windows.Forms.GroupBox flagsGrp;
+        private System.Windows.Forms.LinkLabel flagsHelpPrefix;
         private System.Windows.Forms.TableLayoutPanel flagsTbl;
         private System.Windows.Forms.Button flagsCmdCheckAll;
         private System.Windows.Forms.Button flagsCmdUncheckAll;
@@ -516,10 +535,5 @@
         private System.Windows.Forms.ListView flagsLstIncluded;
         private System.Windows.Forms.TextBox flagsTxtPrefix;
         private System.Windows.Forms.Label flagsLblPrefix;
-        private System.Windows.Forms.SplitContainer splitContainer;
-        private System.Windows.Forms.LinkLabel genreHelpPrefix;
-        private System.Windows.Forms.LinkLabel genreHelpRemoveExisting;
-        private System.Windows.Forms.ToolTip ttHelp;
-        private System.Windows.Forms.LinkLabel flagsHelpPrefix;
     }
 }

--- a/Depressurizer/DlgAutoCat.cs
+++ b/Depressurizer/DlgAutoCat.cs
@@ -21,10 +21,10 @@ namespace Depressurizer {
 
         #region UI Uptaters
 
-        private void FillGenreList() {
+        private void FillGenreList(bool useTags = false) {
             genreLstIgnore.Items.Clear();
             if( Program.GameDB != null ) {
-                SortedSet<string> genreList = Program.GameDB.GetAllGenres();
+                SortedSet<string> genreList = Program.GameDB.GetAllGenres(useTags);
                 foreach( string s in genreList ) {
                     genreLstIgnore.Items.Add( s );
                 }
@@ -78,6 +78,7 @@ namespace Depressurizer {
             genreChkRemoveExisting.Checked = ac.RemoveOtherGenres;
             genreNumMaxCats.Value = ac.MaxCategories;
             genreTxtPrefix.Text = ac.Prefix;
+            genreChkUseTags.Checked = ac.UseTags;
 
             foreach( ListViewItem item in genreLstIgnore.Items ) {
                 item.Checked = ac.IgnoredGenres.Contains( item.Text );
@@ -113,6 +114,7 @@ namespace Depressurizer {
             ac.Prefix = genreTxtPrefix.Text;
             ac.MaxCategories = (int)genreNumMaxCats.Value;
             ac.RemoveOtherGenres = genreChkRemoveExisting.Checked;
+            ac.UseTags = genreChkUseTags.Checked;
 
             ac.IgnoredGenres.Clear();
             foreach( ListViewItem i in genreLstIgnore.Items ) {
@@ -253,6 +255,10 @@ namespace Depressurizer {
 
         private void cmdRename_Click( object sender, EventArgs e ) {
             RenameAutoCat( lstAutoCats.SelectedItem as AutoCat );
+        }
+
+        private void genreChkUseTags_CheckChanged( object sender, EventArgs e ) {
+            FillGenreList( genreChkUseTags.Checked );
         }
 
         #endregion

--- a/Depressurizer/GameDB.cs
+++ b/Depressurizer/GameDB.cs
@@ -334,7 +334,7 @@ namespace Depressurizer {
             foreach( GameDBEntry entry in Games.Values ) {
                 string fullGenreString = entry.Genre;
                 if( useTags && !string.IsNullOrEmpty(entry.Tags) ) {
-                    fullGenreString += ", " + entry.Tags;
+                    fullGenreString += ( !string.IsNullOrEmpty(fullGenreString ) ? ", " : "" ) + entry.Tags;
                 }
                 if( !string.IsNullOrEmpty( fullGenreString ) ) {
                     string[] genreStrings = fullGenreString.Split( genreSep );

--- a/Depressurizer/GameDB.cs
+++ b/Depressurizer/GameDB.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
+using System.Web;
 using System.Xml;
 using Rallion;
 using System.IO.Compression;
@@ -51,7 +52,7 @@ namespace Depressurizer {
         private static Regex regGamecheck = new Regex( "<a[^>]*>All Games</a>", RegexOptions.IgnoreCase | RegexOptions.Compiled );
 
         private static Regex regGenre = new Regex( "<div class=\\\"details_block\\\">\\s*<b>Title:</b>[^<]*<br>\\s*<b>Genre:</b>\\s*(<a[^>]*>([^<]+)</a>,?\\s*)+\\s*<br>", RegexOptions.Compiled | RegexOptions.IgnoreCase );
-        private static Regex regTags = new Regex( @"<div[^>]+class=""glance_tags popular_tags""[^>]*>(\s*<a[^>]+class=""app_tag""[^>]*>\s*([a-z0-9][a-z0-9\-\s]*[a-z0-9])\s*</a>)+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static Regex regTags = new Regex( @"<div[^>]+class=""glance_tags popular_tags""[^>]*>(\s*<a[^>]+class=""app_tag""[^>]*>\s*([a-z0-9][a-z0-9\-\s&;'\.]*[a-z0-9])\s*</a>)+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         //private static Regex regDLC = new Regex("<div class=\\\"name\\\"><a href=[^>]*>Downloadable Content</a></div>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static Regex regFlags = new Regex( "<a href=\\\"http://store.steampowered.com/search/\\?category2=[0-9]+\\\" class=\\\"name\\\">([^<]*)</a>", RegexOptions.IgnoreCase | RegexOptions.Compiled );
@@ -187,7 +188,7 @@ namespace Depressurizer {
                 int genres = m.Groups[2].Captures.Count;
                 string[] array = new string[genres];
                 for( int i = 0; i < genres; i++ ) {
-                    array[i] = m.Groups[2].Captures[i].Value;
+                    array[i] = HttpUtility.HtmlDecode(m.Groups[2].Captures[i].Value);
                 }
                 this.Genre = string.Join( ", ", array );
                 return true;
@@ -198,7 +199,7 @@ namespace Depressurizer {
         private bool GetTagsFromPage( string page ) {
             var m = regTags.Match(page);
             if( m.Success ) {
-                var tags = ( from object capture in m.Groups[2].Captures select capture.ToString() )
+                var tags = ( from object capture in m.Groups[2].Captures select HttpUtility.HtmlDecode(capture.ToString()) )
                            .ToList();
 
                 this.Tags = string.Join( ", ", tags.Take( 5 ) );


### PR DESCRIPTION
Added a flag in the AutoCat edit dialog for using Popular Tags along with the Steam supplied "Genres". Each GameEntry gets a new field called "Tags" which function similarly to Genres, but I figured it would be better to separate them out.

It's not super ideal, but at the very least you can rip out the regex and use that for something else.

Also, sorry about the regenerated resx and Designer files. Apparently my VS instance just stomped all over that
