### PR TITLE
Fixed search bug

### DIFF
--- a/Depressurizer/MainForm.cs
+++ b/Depressurizer/MainForm.cs
@@ -979,6 +979,11 @@ namespace Depressurizer {
                     if( ShouldDisplayGame( g ) ) {
                         displayedGames.Add( g );
                     }
+
+					if ( g.Name == null ) {
+						g.Name = string.Empty;
+						displayedGames.Add( g );
+					}
                 }
                 displayedGames.Sort( displayedGamesSorter );
             }


### PR DESCRIPTION
Search bug caused program to crash if a game initialized with a null
title. Fixed by replacing null title with a string.empty title. Fixes #29 
