### PR TITLE
VDF Parsing Bugfix: Adding support for UInt64 VDF values

### DIFF
--- a/Depressurizer/VdfFile/VdfFileNode.cs
+++ b/Depressurizer/VdfFile/VdfFileNode.cs
@@ -125,6 +125,15 @@ namespace Depressurizer {
             NodeData = (Int32)( value );
         }
 
+        /// <summary>
+        /// Creates a new UInt64-type node
+        /// </summary>
+        /// <param name="value">Value of the unsigned 64-bit integer</param>
+        public VdfFileNode( ulong value ) {
+            NodeType = ValueType.Int;
+            NodeData = (UInt64)( value );
+        }
+
         #region Utility
 
         /// <summary>
@@ -254,6 +263,10 @@ namespace Depressurizer {
                 } else if( nextByte == 2 ) {
                     key = ReadBin_GetStringToken( stream );
                     int val = stream.ReadInt32();
+                    thisLevel[key] = new VdfFileNode( val );
+                } else if( nextByte == 7 ) {
+                    key = ReadBin_GetStringToken( stream );
+                    ulong val = stream.ReadUInt64();
                     thisLevel[key] = new VdfFileNode( val );
                 } else if( nextByte == 0xFF ) {
                     return null;


### PR DESCRIPTION
This fix allows Depressurizer to parse the 'packageinfo.vdf' file for those of us who have the "base goldsrc" apps (appids 0, 1, and 2) -- for some reason it just affects these three, as far as I can tell.

A quick google search tells me that at least one other person has encountered this:
http://www.reddit.com/r/Steam/comments/2fgjvt/the_steam_category_manager_depressurizer_updated/coohpfo

I tried to make as few changes as possible for easy merging. But I if you are interested, I can submit an additional PR (once this one is merged into `dev`) that simplifies the code a little and gives it support for even more data types, which would further improve compatibility. Let me know if that would be useful for you.

Cheers.
